### PR TITLE
Add Javadocs for public classes and methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,8 @@ javadoc {
         encoding = "UTF-8"
         overview = "src/main/html/overview.html"
         links "https://docs.oracle.com/javase/8/docs/api/"
+        links "https://dev.embulk.org/embulk-util-config/0.1.1/javadoc/"
+        links "https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/"
     }
 }
 

--- a/src/main/html/overview.html
+++ b/src/main/html/overview.html
@@ -6,5 +6,6 @@
   </head>
   <body>
     <p>AWS client credential handler for Embulk plugins.</p>
+    <p>Note that this is expected to use with <a href="https://dev.embulk.org/embulk-util-config/"><code>embulk-util-config</code></a>, not with Embulk core's <code>ConfigSource#loadConfig</code> nor <code>TaskSource#loadTask</code>.
   </body>
 </html>

--- a/src/main/java/org/embulk/util/aws/credentials/AwsCredentials.java
+++ b/src/main/java/org/embulk/util/aws/credentials/AwsCredentials.java
@@ -20,14 +20,30 @@ import org.embulk.config.ConfigException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A utility class to generate {@link com.amazonaws.auth.AWSCredentialsProvider} from Embulk's task-defining interface.
+ */
 public abstract class AwsCredentials {
     private AwsCredentials() {
+        // No instantiation.
     }
 
+    /**
+     * Creates {@link com.amazonaws.auth.AWSCredentialsProvider} from entries prefixed with {@code "aws_"} in task definition.
+     *
+     * @param task  An entry in Embulk's task defining interface
+     * @return {@link com.amazonaws.auth.AWSCredentialsProvider} created
+     */
     public static AWSCredentialsProvider getAWSCredentialsProvider(AwsCredentialsTaskWithPrefix task) {
         return getAWSCredentialsProvider("aws_", task);
     }
 
+    /**
+     * Creates {@link com.amazonaws.auth.AWSCredentialsProvider} from entries in task definition.
+     *
+     * @param task  An entry in Embulk's task defining interface
+     * @return {@link com.amazonaws.auth.AWSCredentialsProvider} created
+     */
     public static AWSCredentialsProvider getAWSCredentialsProvider(AwsCredentialsTask task) {
         return getAWSCredentialsProvider("", task);
     }

--- a/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsConfig.java
+++ b/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsConfig.java
@@ -2,28 +2,119 @@ package org.embulk.util.aws.credentials;
 
 import java.util.Optional;
 
-public interface AwsCredentialsConfig {
+interface AwsCredentialsConfig {
+    /**
+     * Gets the authentication method configured.
+     *
+     * @return The authentication method configured.
+     */
     String getAuthMethod();
 
+    /**
+     * Sets an authentication method to configure.
+     *
+     * @param method  One of authentication methods from {@code "basic"}, {@code "env"}, {@code "instance"},
+     *     {@code "profile"}, {@code "properties"}, {@code "anonymous"}, {@code "session"}, and {@code "default"}.
+     */
     void setAuthMethod(String method);
 
+    /**
+     * Gets the AWS IAM access key ID configured.
+     *
+     * <p>It is available only when the authentication method is set to: {@code "basic"} or {@code "session"}.
+     *
+     * @return The AWS IAM access key ID configured. (For example, {@code AKIAIOSFODNN7EXAMPLE})
+     * @see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html">Managing Access Keys for IAM Users</a>
+     */
     Optional<String> getAccessKeyId();
 
+    /**
+     * Sets an AWS IAM access key ID to configure.
+     *
+     * <p>It is available only when the authentication method is set to: {@code "basic"} or {@code "session"}.
+     *
+     * @param value  An AWS IAM access key ID to configure. (For example, {@code AKIAIOSFODNN7EXAMPLE})
+     * @see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html">Managing Access Keys for IAM Users</a>
+     */
     void setAccessKeyId(Optional<String> value);
 
+    /**
+     * Gets the AWS IAM secret access key configured.
+     *
+     * <p>It is available only when the authentication method is set to: {@code "basic"} or {@code "session"}.
+     *
+     * @return The AWS IAM secret access key configured. (For example, {@code wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY})
+     * @see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html">Managing Access Keys for IAM Users</a>
+     */
     Optional<String> getSecretAccessKey();
 
+    /**
+     * Sets an AWS IAM secret access key to configure.
+     *
+     * <p>It is available only when the authentication method is set to: {@code "basic"} or {@code "session"}.
+     *
+     * @param value  The AWS IAM secret access key to configure. (For example, {@code wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY})
+     * @see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html">Managing Access Keys for IAM Users</a>
+     */
     void setSecretAccessKey(Optional<String> value);
 
+    /**
+     * Gets the AWS IAM session token configured.
+     *
+     * <p>It is available only when the authentication method is set to: {@code "session"}.
+     *
+     * @return The AWS IAM session token configured.
+     * @see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html">Using Temporary Credentials With AWS Resources</a>
+     */
     Optional<String> getSessionToken();
 
+    /**
+     * Sets an AWS IAM session token to configure.
+     *
+     * <p>It is available only when the authentication method is set to: {@code "session"}.
+     *
+     * @param value  The AWS IAM session token to configure
+     * @see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html">Using Temporary Credentials With AWS Resources</a>
+     */
     void setSessionToken(Optional<String> value);
 
+    /**
+     * Gets the path to an AWS IAM profile file configured.
+     *
+     * <p>It is available only when the authentication method is set to: {@code "profile"}.
+     *
+     * @return The path to an AWS IAM profile file configured
+     * @see <a href="https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html">Named profiles</a>
+     */
     Optional<String> getProfileFile();
 
+    /**
+     * Sets a path to an AWS IAM profile file to configure.
+     *
+     * <p>It is available only when the authentication method is set to: {@code "profile"}.
+     *
+     * @param value  The path to an AWS IAM profile file to configure
+     * @see <a href="https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html">Named profiles</a>
+     */
     void setProfileFile(Optional<String> value);
 
+    /**
+     * Gets the name in an AWS IAM profile file configured.
+     *
+     * <p>It is available only when the authentication method is set to: {@code "profile"}.
+     *
+     * @return The name in an AWS IAM profile file configured
+     * @see <a href="https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html">Named profiles</a>
+     */
     Optional<String> getProfileName();
 
+    /**
+     * Sets a name in an AWS IAM profile file to configure.
+     *
+     * <p>It is available only when the authentication method is set to: {@code "profile"}.
+     *
+     * @param value  The name in an AWS IAM profile file to configure
+     * @see <a href="https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html">Named profiles</a>
+     */
     void setProfileName(Optional<String> value);
 }

--- a/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsTask.java
+++ b/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsTask.java
@@ -4,6 +4,9 @@ import java.util.Optional;
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
 
+/**
+ * An {@code interface} for Embulk's task-defining interface.
+ */
 public interface AwsCredentialsTask extends AwsCredentialsConfig {
     @Override
     @Config("auth_method")

--- a/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsTaskWithPrefix.java
+++ b/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsTaskWithPrefix.java
@@ -4,6 +4,9 @@ import java.util.Optional;
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
 
+/**
+ * An {@code interface} for Embulk's task-defining interface, with entries prefixed with {@code "aws_"}.
+ */
 public interface AwsCredentialsTaskWithPrefix extends AwsCredentialsConfig {
     @Override
     @Config("aws_auth_method")


### PR DESCRIPTION
It makes `AwsCredentialsConfig` package-private as unnecessary.