### PR TITLE
Add web_identity_token authentication

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,14 +29,14 @@ dependencies {
 
     api "org.embulk:embulk-util-config:0.1.1"
 
-    api("com.amazonaws:aws-java-sdk-s3:1.11.466") {
+    api("com.amazonaws:aws-java-sdk-s3:1.11.880") {
         exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
         exclude group: "commons-logging", module: "commons-logging"   // commons-logging api is provided by jcl-over-slf4j
         exclude group: "joda-time", module: "joda-time"
     }
-    api("com.amazonaws:aws-java-sdk-sts:1.11.466") {
+    api("com.amazonaws:aws-java-sdk-sts:1.11.880") {
         exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
         exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,19 +1,19 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.amazonaws:aws-java-sdk-core:1.11.466
-com.amazonaws:aws-java-sdk-kms:1.11.466
-com.amazonaws:aws-java-sdk-s3:1.11.466
-com.amazonaws:aws-java-sdk-sts:1.11.466
-com.amazonaws:jmespath-java:1.11.466
+com.amazonaws:aws-java-sdk-core:1.11.880
+com.amazonaws:aws-java-sdk-kms:1.11.880
+com.amazonaws:aws-java-sdk-s3:1.11.880
+com.amazonaws:aws-java-sdk-sts:1.11.880
+com.amazonaws:jmespath-java:1.11.880
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.7
-commons-codec:commons-codec:1.10
+commons-codec:commons-codec:1.11
 joda-time:joda-time:2.9.2
-org.apache.httpcomponents:httpclient:4.5.5
-org.apache.httpcomponents:httpcore:4.4.9
+org.apache.httpcomponents:httpclient:4.5.9
+org.apache.httpcomponents:httpcore:4.4.11
 org.embulk:embulk-api:0.10.5
 org.embulk:embulk-util-config:0.1.1
 org.slf4j:jcl-over-slf4j:1.7.12

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,21 +1,21 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.amazonaws:aws-java-sdk-core:1.11.466
-com.amazonaws:aws-java-sdk-kms:1.11.466
-com.amazonaws:aws-java-sdk-s3:1.11.466
-com.amazonaws:aws-java-sdk-sts:1.11.466
-com.amazonaws:jmespath-java:1.11.466
+com.amazonaws:aws-java-sdk-core:1.11.880
+com.amazonaws:aws-java-sdk-kms:1.11.880
+com.amazonaws:aws-java-sdk-s3:1.11.880
+com.amazonaws:aws-java-sdk-sts:1.11.880
+com.amazonaws:jmespath-java:1.11.880
 com.fasterxml.jackson.core:jackson-annotations:2.6.7
 com.fasterxml.jackson.core:jackson-core:2.6.7
 com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
-commons-codec:commons-codec:1.10
+commons-codec:commons-codec:1.11
 javax.validation:validation-api:1.1.0.Final
 joda-time:joda-time:2.9.2
-org.apache.httpcomponents:httpclient:4.5.5
-org.apache.httpcomponents:httpcore:4.4.9
+org.apache.httpcomponents:httpclient:4.5.9
+org.apache.httpcomponents:httpcore:4.4.11
 org.embulk:embulk-util-config:0.1.1
 org.slf4j:jcl-over-slf4j:1.7.12
 software.amazon.ion:ion-java:1.0.2

--- a/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsConfig.java
+++ b/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsConfig.java
@@ -14,7 +14,7 @@ interface AwsCredentialsConfig {
      * Sets an authentication method to configure.
      *
      * @param method  One of authentication methods from {@code "basic"}, {@code "env"}, {@code "instance"},
-     *     {@code "profile"}, {@code "properties"}, {@code "anonymous"}, {@code "session"}, and {@code "default"}.
+     *     {@code "profile"}, {@code "properties"}, {@code "anonymous"}, {@code "session"}, {@code "web_identity_token"}, and {@code "default"}.
      */
     void setAuthMethod(String method);
 
@@ -117,4 +117,65 @@ interface AwsCredentialsConfig {
      * @see <a href="https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html">Named profiles</a>
      */
     void setProfileName(Optional<String> value);
+
+    /**
+     * Gets the AWS IAM Role Arn configured.
+     *
+     * <p>It is available only when the authentication method is set to: {@code "web_identity_token"}.
+     *
+     * @return The AWS IAM Role Arn configured
+     * @see <a href="https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html">AssumeRoleWithWebIdentity</a>
+     */
+    Optional<String> getRoleArn();
+
+    /**
+     * Sets an AWS IAM Role Arn to configure.
+     *
+     * <p>It is available only when the authentication method is set to: {@code "web_identity_token"}.
+     *
+     * @param value  The AWS IAM Role Arn to configure
+     * @see <a href="https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html">AssumeRoleWithWebIdentity</a>
+     */
+    void setRoleArn(Optional<String> value);
+
+    /**
+     * Gets the AWS IAM Role session name configured.
+     *
+     * <p>It is available only when the authentication method is set to: {@code "web_identity_token"}.
+     *
+     * @return The AWS IAM Role session name configured
+     * @see <a href="https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html">AssumeRoleWithWebIdentity</a>
+     */
+    Optional<String> getRoleSessionName();
+
+    /**
+     * Sets an AWS IAM Role session name to configure.
+     *
+     * <p>It is available only when the authentication method is set to: {@code "web_identity_token"}.
+     *
+     * @param value  The AWS IAM Role session name to configure
+     * @see <a href="https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html">AssumeRoleWithWebIdentity</a>
+     */
+    void setRoleSessionName(Optional<String> value);
+
+    /**
+     * Gets the name in a web identity token file configured.
+     *
+     * <p>It is available only when the authentication method is set to: {@code "web_identity_token"}.
+     *
+     * @return The name in a web identity token file configured
+     * @see <a href="https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html">AssumeRoleWithWebIdentity</a>
+     */
+    Optional<String> getWebIdentityTokenFile();
+
+    /**
+     * Sets a name in a web identity token file to configure.
+     *
+     * <p>It is available only when the authentication method is set to: {@code "web_identity_token"}.
+     *
+     * @param value  The name in a web identity token file to configure
+     * @see <a href="https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html">AssumeRoleWithWebIdentity</a>
+     */
+    void setWebIdentityTokenFile(Optional<String> value);
+
 }

--- a/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsTask.java
+++ b/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsTask.java
@@ -44,7 +44,7 @@ public interface AwsCredentialsTask extends AwsCredentialsConfig {
     Optional<String> getRoleArn();
 
     @Override
-    @Config("role_seeeion_name")
+    @Config("role_session_name")
     @ConfigDefault("null")
     Optional<String> getRoleSessionName();
 

--- a/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsTask.java
+++ b/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsTask.java
@@ -37,4 +37,19 @@ public interface AwsCredentialsTask extends AwsCredentialsConfig {
     @Config("profile_name")
     @ConfigDefault("null")
     Optional<String> getProfileName();
+
+    @Override
+    @Config("role_arn")
+    @ConfigDefault("null")
+    Optional<String> getRoleArn();
+
+    @Override
+    @Config("role_seeeion_name")
+    @ConfigDefault("null")
+    Optional<String> getRoleSessionName();
+
+    @Override
+    @Config("web_identity_token_file")
+    @ConfigDefault("null")
+    Optional<String> getWebIdentityTokenFile();
 }

--- a/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsTaskWithPrefix.java
+++ b/src/main/java/org/embulk/util/aws/credentials/AwsCredentialsTaskWithPrefix.java
@@ -37,4 +37,19 @@ public interface AwsCredentialsTaskWithPrefix extends AwsCredentialsConfig {
     @Config("aws_profile_name")
     @ConfigDefault("null")
     Optional<String> getProfileName();
+
+    @Override
+    @Config("aws_role_arn")
+    @ConfigDefault("null")
+    Optional<String> getRoleArn();
+
+    @Override
+    @Config("aws_role_session_name")
+    @ConfigDefault("null")
+    Optional<String> getRoleSessionName();
+
+    @Override
+    @Config("aws_web_identity_token_file")
+    @ConfigDefault("null")
+    Optional<String> getWebIdentityTokenFile();
 }


### PR DESCRIPTION
Add `web_identity_token` authentication using [WebIdentityTokenCredentialsProvider](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/WebIdentityTokenCredentialsProvider.html).
It is motivated to use IAM Role with Embulk application on Kubernetes(ref: [Introducing fine-grained IAM roles for service accounts](https://aws.amazon.com/jp/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/))

Changes
- Upgrade aws-java-sdk to `1.11.880` for use `WebIdentityTokenCredentialsProvider` (required version >=1.11.623).
- implement `web_identity_token` authentication.
- Add `role_arn`, `role_session_name`, `web_identity_token_file` configs for `web_identity_token` authentication.
  - These are optional. if empty, getting value from environment variables (`AWS_ROLE_ARN`, `AWS_ROLE_SESSION_NAME`, `AWS_WEB_IDENTITY_TOKEN_FILE`) in `WebIdentityTokenCredentialsProvider`.