### PR TITLE
Allow externalId optional

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "org.embulk"
-version = "0.4.1-SNAPSHOT"
+version = "0.4.2-SNAPSHOT"
 description = "AWS client credential handler for Embulk plugins"
 
 sourceCompatibility = 1.8

--- a/src/main/java/org/embulk/util/aws/credentials/AwsCredentials.java
+++ b/src/main/java/org/embulk/util/aws/credentials/AwsCredentials.java
@@ -218,7 +218,10 @@ public abstract class AwsCredentials {
             STSAssumeRoleSessionCredentialsProvider.Builder builder
                     = new STSAssumeRoleSessionCredentialsProvider.Builder(arn, task.getSessionName());
             if (task.getExternalId().isPresent()) {
+                log.info("ExternalId is specified with AssumeRole.");
                 builder.withExternalId(task.getExternalId().get());
+            } else {
+                log.info("ExternalId is not specified for AssumeRole.");
             }
             return builder.withRoleSessionDurationSeconds(task.getDurationInSeconds())
                     .build();

--- a/src/main/java/org/embulk/util/aws/credentials/AwsCredentials.java
+++ b/src/main/java/org/embulk/util/aws/credentials/AwsCredentials.java
@@ -211,16 +211,16 @@ public abstract class AwsCredentials {
                     "'" + accountIdOption + "'");
             final String roleName = require(task.getRoleName(),
                     "'" + roleNameOption + "'");
-            final String externalId = require(task.getExternalId(),
-                    "'" + externalIdOption + "'");
             final String arn = String.format(ARN_PATTERN, task.getArnPartition(), accountId, roleName);
 
             // use AWSSecurityTokenServiceClient with DefaultAWSCredentialsProviderChain
             // https://javadoc.io/doc/com.amazonaws/aws-java-sdk-sts/1.11.0/com/amazonaws/services/securitytoken/AWSSecurityTokenServiceClient.html#AWSSecurityTokenServiceClient()
             STSAssumeRoleSessionCredentialsProvider.Builder builder
                     = new STSAssumeRoleSessionCredentialsProvider.Builder(arn, task.getSessionName());
-            return builder.withExternalId(externalId)
-                    .withRoleSessionDurationSeconds(task.getDurationInSeconds())
+            if (task.getExternalId().isPresent()) {
+                builder.withExternalId(task.getExternalId().get());
+            }
+            return builder.withRoleSessionDurationSeconds(task.getDurationInSeconds())
                     .build();
         }
 


### PR DESCRIPTION
In some environments, it doesn't require an ExternalId when assuming a role. e.g. assuming a role in the same account. This PR proposes a change that allows an externalID optional.